### PR TITLE
Fix build of c-ear on Ubuntu 20.04

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,6 @@ target_compile_options(${PROJECT_NAME}
 set_target_properties(${PROJECT_NAME}
     PROPERTIES
     C_STANDARD 17
-    C_STANDARD_REQUIRED ON
+    C_STANDARD_REQUIRED OFF
     C_EXTENSIONS OFF
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ target_compile_options(${PROJECT_NAME}
 
 set_target_properties(${PROJECT_NAME}
     PROPERTIES
-    C_STANDARD 17
+    C_STANDARD 11
     C_STANDARD_REQUIRED OFF
     C_EXTENSIONS OFF
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,7 @@ set_target_properties(ear PROPERTIES PUBLIC_HEADER "ear.h")
 
 install(TARGETS ear
     LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
     PUBLIC_HEADER DESTINATION include
 )
 


### PR DESCRIPTION
Fix issues trying to compile c-ear on an Ubuntu 20.04 environment.
Revise the C dialect directives for compatibility with toolchains on Ubuntu 20.04.
Also define an ARCHIVE install location in addition to LIBRARY

Signed-off-by: Paul Howard <paul.howard@arm.com>